### PR TITLE
bugfix: add check for aa51

### DIFF
--- a/packages/validation/src/ValidationService.ts
+++ b/packages/validation/src/ValidationService.ts
@@ -234,6 +234,11 @@ export class ValidationService {
       ValidationErrors.UnsupportedSignatureAggregator
     )
 
+    // check aa51
+    const verificationCost = BigNumber.from(res.returnInfo.preOpGas).sub(userOp.preVerificationGas)
+    const extraGas = BigNumber.from(userOp.verificationGasLimit).sub(verificationCost).toNumber()
+    requireCond(extraGas >= 2000, `verificationGas should have extra 2000 gas. has only ${extraGas}`, ValidationErrors.SimulateValidation)
+
     Logger.debug({ userOp }, 'UserOp passed validation')
     return {
       ...res,


### PR DESCRIPTION
## Why
A bug found in v0.6 requires bundlers' attention, and a new test, `test_enough_verification_gas` has been added to "bundler-spec-test" repo, on branch [releases/v0.6"](https://github.com/eth-infinitism/bundler-spec-tests/tree/releases/v0.6), PR [here](https://github.com/eth-infinitism/bundler-spec-tests/pull/57) to address the bug. Let's get the transept-bundler to pass this test.

## How

Add check for check AA51 to pass `test_enough_verification_gas` bundler spec test.

## Test locally
To run it on bundler-spec-test repo:

1. First, navigate  to transeptor-bundler repo
2. Start up geth node: `npm run geth-node`
3. Fund bundler signer wallet/deploy entrypoint: ` npm run bundler-prep`
4. Start up transeptor: `npm run start:dev `
5. While transeptor-bundler is running navigate to bundler-spec-test repo and run:`pdm run test -k test_enough_verification_gas --log-rpc -vvv --url http://127.0.0.1:4000/rpc/ --entry-point 0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789 --ethereum-node http://localhost:8545
`

<img width="1440" alt="Screenshot 2024-02-19 at 2 15 57 PM" src="https://github.com/transeptorlabs/transeptor-bundler/assets/34751375/34e7d932-2864-46ba-960a-0e25b5af9c65">