### PR TITLE
bugfix: fix bug that was causing replace op spec test to fail

### DIFF
--- a/packages/bundler-builder/src/mempool/mempool-manager.ts
+++ b/packages/bundler-builder/src/mempool/mempool-manager.ts
@@ -352,6 +352,7 @@ export const createMempoolManager = (
         await mp.updateState(
           MempoolStateKey.StandardPool,
           ({ standardPool }) => {
+            delete standardPool[oldEntry.userOpHash]
             return {
               standardPool: {
                 ...standardPool,

--- a/packages/bundler-relayer/src/handler/request-router.ts
+++ b/packages/bundler-relayer/src/handler/request-router.ts
@@ -1,11 +1,19 @@
 import { providers } from 'ethers'
+import { RpcError } from '../../../shared/utils/index.js'
+import { JsonRpcErrorResponse } from '../../../shared/rpc'
 
-export const routeRequest = async (
+export const routeRequest = async <T>(
   bundlerBuilderClientUrl: string,
   method: string,
   params: any[],
-) => {
-  const provider = new providers.StaticJsonRpcProvider(bundlerBuilderClientUrl)
-  // TODO: We can catch error and extract error message
-  return await provider.send(method, params)
+): Promise<T | RpcError> => {
+  try {
+    const provider = new providers.StaticJsonRpcProvider(
+      bundlerBuilderClientUrl,
+    )
+    return await provider.send(method, params)
+  } catch (error: any) {
+    const parseJson: JsonRpcErrorResponse = JSON.parse(error.body)
+    return new RpcError(parseJson.error.message, parseJson.error.code)
+  }
 }

--- a/packages/shared/validatation/validation.types.ts
+++ b/packages/shared/validatation/validation.types.ts
@@ -42,7 +42,12 @@ export type ValidateUserOpResult = ValidationResult & {
 }
 
 export enum ValidationErrors {
+  ParseError = -32700,
+  InvalidRequest = -32600,
+  MethodNotFound = -32601,
   InvalidFields = -32602,
+  InternalError = -32603,
+
   SimulateValidation = -32500,
   SimulatePaymasterValidation = -32501,
   OpcodeValidation = -32502,
@@ -51,6 +56,7 @@ export enum ValidationErrors {
   InsufficientStake = -32505,
   UnsupportedSignatureAggregator = -32506,
   InvalidSignature = -32507,
+  PaymasterDepositTooLow = -32508,
   UserOperationReverted = -32521,
 }
 


### PR DESCRIPTION
Fix a bug that was causing the replace op spec test to fail. Transeptor bundler now passes all `test_bundle_replace_op.`

```shell
PASSED tests/single/bundle/test_bundle.py::test_bundle_replace_op[only_priority_fee_bump]
PASSED tests/single/bundle/test_bundle.py::test_bundle_replace_op[only_max_fee_bump]
PASSED tests/single/bundle/test_bundle.py::test_bundle_replace_op[with_same_fee]
PASSED tests/single/bundle/test_bundle.py::test_bundle_replace_op[with_less_fee]
PASSED tests/single/bundle/test_bundle.py::test_bundle_replace_op[fee_bump_below_threshold]
PASSED tests/single/bundle/test_bundle.py::test_bundle_replace_op[fee_bump_at_threshold]
PASSED tests/single/bundle/test_bundle.py::test_bundle_replace_op[fee_bump_above_threshold]
==================================================================== 7 passed, 177 deselected in 2.56s =====================================================================
```