### PR TITLE
bugfix: pass max allowed ops unstaked sender spec test

### DIFF
--- a/packages/bundler-builder/src/mempool/mempool-manager.ts
+++ b/packages/bundler-builder/src/mempool/mempool-manager.ts
@@ -146,7 +146,14 @@ export const createMempoolManager = (
     )
   }
 
-  // Funtions to interface with reputationManager
+  /**
+   * Checks the reputation status of the given stakeInfo.
+   * Banned: If the entity is banned, an error is thrown as banned entities are not allowed to add UserOperations.
+   *
+   * @param title - The title of the entity to check the reputation status for.
+   * @param stakeInfo - The StakeInfo of the entity to check the reputation status for.
+   * @param maxTxMempoolAllowedOverride  - The maximum number of transactions allowed in the mempool for the entity.
+   */
   const checkReputationStatus = async (
     title: 'account' | 'paymaster' | 'aggregator' | 'deployer',
     stakeInfo: StakeInfo,
@@ -167,7 +174,7 @@ export const createMempoolManager = (
     if (foundCount > THROTTLED_ENTITY_MEMPOOL_COUNT) {
       await reputationManager.checkThrottled(title, stakeInfo)
     }
-    if (foundCount > maxTxMempoolAllowedEntity) {
+    if (foundCount >= maxTxMempoolAllowedEntity) {
       await reputationManager.checkStake(title, stakeInfo)
     }
   }
@@ -200,10 +207,8 @@ export const createMempoolManager = (
   const updateSeenStatus = async (
     aggregator: string | undefined,
     userOp: UserOperation,
-    senderInfo: StakeInfo,
   ): Promise<void> => {
     try {
-      await reputationManager.checkStake('account', senderInfo)
       await reputationManager.updateSeenStatus(userOp.sender)
     } catch (e: any) {
       if (!(e instanceof RpcError)) throw e
@@ -425,7 +430,7 @@ export const createMempoolManager = (
         )
       }
 
-      await updateSeenStatus(aggregatorInfo?.addr, userOp, senderInfo)
+      await updateSeenStatus(aggregatorInfo?.addr, userOp)
       Logger.debug(
         {
           sender: userOp.sender,

--- a/packages/bundler-builder/src/reputation/reputation-manager.ts
+++ b/packages/bundler-builder/src/reputation/reputation-manager.ts
@@ -336,12 +336,12 @@ export const createReputationManager = (
       title: 'account' | 'paymaster' | 'aggregator' | 'deployer',
       info?: StakeInfo,
     ): Promise<void> => {
-      // If the address is whitelisted, we don't need to check the stake
-      const status = await getStatus(info.addr)
-      if (info?.addr == null || status === ReputationStatus.OK) {
+      if (info?.addr == null) {
         return
       }
 
+      // If the address is whitelisted, we don't need to check the stake
+      const status = await getStatus(info.addr)
       requireCond(
         status !== ReputationStatus.BANNED,
         `${title} ${info.addr} is banned`,
@@ -349,6 +349,7 @@ export const createReputationManager = (
         { [title]: info.addr },
       )
 
+      // Check if min stake and unstake delay are met
       requireCond(
         BigNumber.from(info.stake).gte(minStake),
         `${title} ${info.addr} stake ${tostr(info.stake)} is too low (min=${tostr(
@@ -356,6 +357,7 @@ export const createReputationManager = (
         )})`,
         ValidationErrors.InsufficientStake,
       )
+
       requireCond(
         BigNumber.from(info.unstakeDelaySec).gte(
           BigNumber.from(minUnstakeDelay),


### PR DESCRIPTION
Fix a bug that was causing the max allowed ops unstaked sender spec test to fail. Transeptor bundler now passes all `test_max_allowed_ops_unstaked_sender.`

```shell
========================================================================= short test summary info ==========================================================================
PASSED tests/single/bundle/test_bundle.py::test_max_allowed_ops_unstaked_sender
=============================================================== 1 passed, 183 deselected, 1 warning in 1.56s ===============================================================
```