### PR TITLE
refactor: define a subset of types for mempool manager

### DIFF
--- a/packages/bundler-builder/src/bundle/bundle-builder.ts
+++ b/packages/bundler-builder/src/bundle/bundle-builder.ts
@@ -1,9 +1,6 @@
 import { BigNumber, ethers } from 'ethers'
 import { Logger } from '../../../shared/logger/index.js'
-import {
-  MempoolEntry,
-  MempoolManager,
-} from '../../../bundler-builder/src/mempool/index.js'
+import { MempoolEntry } from '../../../bundler-builder/src/mempool/index.js'
 import { StorageMap, UserOperation } from '../../../shared/types/index.js'
 import { mergeStorageMap } from '../../../shared/utils/index.js'
 import {
@@ -14,45 +11,37 @@ import { ReputationManager, ReputationStatus } from '../reputation/index.js'
 import { ProviderService } from '../../../shared/provider/provider-service.js'
 
 export type BundleBuilder = {
-  createBundle: (force: boolean) => Promise<[UserOperation[], StorageMap]>
+  createBundle: (
+    entries: MempoolEntry[],
+    knownSenders: string[],
+  ) => Promise<BundleReadyToSend>
+}
+
+export type BundleReadyToSend = {
+  bundle: UserOperation[]
+  storageMap: StorageMap
+  notIncludedUserOpsHashes: string[]
+  markedToRemoveUserOpsHashes: string[]
 }
 
 export const createBundleBuilder = (
   providerService: ProviderService,
   validationService: ValidationService,
   reputationManager: ReputationManager,
-  mempoolManager: MempoolManager,
-  maxBundleGas: number,
-  isUnsafeMode: boolean,
-  txMode: string,
-  entryPointContract: ethers.Contract,
+  opts: {
+    maxBundleGas: number
+    isUnsafeMode: boolean
+    txMode: string
+    entryPointContract: ethers.Contract
+  },
 ): BundleBuilder => {
   const THROTTLED_ENTITY_BUNDLE_COUNT = 4
 
-  const getEntries = async (force?: boolean): Promise<MempoolEntry[]> => {
-    if ((await mempoolManager.size()) === 0) {
-      return []
-    }
-
-    // TODO: Include entries based off highest fee
-    // if force is true, send the all pending UserOps in the mempool as a bundle
-    const entries: MempoolEntry[] = force
-      ? await mempoolManager.getAllPending()
-      : await mempoolManager.getNextPending()
-
-    return entries
-  }
-
   return {
     createBundle: async (
-      force?: boolean,
-    ): Promise<[UserOperation[], StorageMap]> => {
-      const entries = await getEntries(force)
-      if (entries.length === 0) {
-        Logger.debug('No entries to bundle')
-        return [[], {}]
-      }
-
+      entries: MempoolEntry[],
+      knownSenders: string[],
+    ): Promise<BundleReadyToSend> => {
       Logger.debug(
         { total: entries.length },
         'Attepting to create bundle from entries',
@@ -63,8 +52,8 @@ export const createBundleBuilder = (
       const paymasterDeposit: { [paymaster: string]: BigNumber } = {} // paymaster deposit should be enough for all UserOps in the bundle.
       const stakedEntityCount: { [addr: string]: number } = {} // throttled paymasters and deployers are allowed only small UserOps per bundle.
       const senders = new Set<string>() // each sender is allowed only once per bundle
-      const knownSenders = await mempoolManager.getKnownSenders()
-      const notIncludedUserOpsHashes = []
+      const notIncludedUserOpsHashes: string[] = []
+      const markedToRemoveUserOpsHashes: string[] = []
 
       mainLoop: for (let i = 0; i < entries.length; i++) {
         const entry = entries[i]
@@ -80,7 +69,7 @@ export const createBundleBuilder = (
           paymasterStatus === ReputationStatus.BANNED ||
           deployerStatus === ReputationStatus.BANNED
         ) {
-          await mempoolManager.removeUserOp(entry.userOpHash)
+          markedToRemoveUserOpsHashes.push(entry.userOpHash)
           continue
         }
 
@@ -128,7 +117,7 @@ export const createBundleBuilder = (
           // re-validate UserOp. no need to check stake, since it cannot be reduced between first and 2nd validation
           validationResult = await validationService.validateUserOp(
             entry.userOp,
-            isUnsafeMode,
+            opts.isUnsafeMode,
             false,
             entry.referencedContracts,
           )
@@ -137,7 +126,7 @@ export const createBundleBuilder = (
             { error: e.message, entry: entry },
             'failed 2nd validation, removing from mempool:',
           )
-          await mempoolManager.removeUserOp(entry.userOpHash)
+          markedToRemoveUserOpsHashes.push(entry.userOpHash)
           continue
         }
 
@@ -161,7 +150,7 @@ export const createBundleBuilder = (
           validationResult.returnInfo.preOpGas,
         ).add(entry.userOp.callGasLimit)
         const newTotalGas = totalGas.add(userOpGasCost)
-        if (newTotalGas.gt(maxBundleGas)) {
+        if (newTotalGas.gt(opts.maxBundleGas)) {
           Logger.debug(
             { stopIndex: i, entriesLength: entries.length },
             'Bundle is full sending user ops back to mempool with status pending',
@@ -178,7 +167,7 @@ export const createBundleBuilder = (
         if (paymaster != null) {
           if (paymasterDeposit[paymaster] == null) {
             paymasterDeposit[paymaster] =
-              await entryPointContract.balanceOf(paymaster)
+              await opts.entryPointContract.balanceOf(paymaster)
           }
           if (
             paymasterDeposit[paymaster].lt(validationResult.returnInfo.prefund)
@@ -199,7 +188,7 @@ export const createBundleBuilder = (
         }
 
         // If sender's account already exist: replace with its storage root hash
-        if (txMode === 'conditional' && entry.userOp.factory === null) {
+        if (opts.txMode === 'conditional' && entry.userOp.factory === null) {
           // in conditionalRpc: always put root hash (not specific storage slots) for "sender" entries
           const { storageHash } = await providerService.send('eth_getProof', [
             entry.userOp.sender,
@@ -220,21 +209,12 @@ export const createBundleBuilder = (
         totalGas = newTotalGas
       }
 
-      // send ops that back to mempool that were not included in the bundle
-      if (notIncludedUserOpsHashes.length > 0) {
-        Logger.debug(
-          { total: notIncludedUserOpsHashes.length },
-          'Bundle full: sending unbundled UserOps back to mempool with status of pending',
-        )
-        for (let i = 0; i < notIncludedUserOpsHashes.length; i++) {
-          await mempoolManager.updateEntryStatus(
-            entries[i].userOpHash,
-            'pending',
-          )
-        }
+      return {
+        bundle,
+        storageMap,
+        notIncludedUserOpsHashes,
+        markedToRemoveUserOpsHashes,
       }
-
-      return [bundle, storageMap]
     },
   }
 }

--- a/packages/bundler-builder/src/bundle/bundle-processor.ts
+++ b/packages/bundler-builder/src/bundle/bundle-processor.ts
@@ -6,7 +6,6 @@ import {
   GET_USEROP_HASHES_BYTECODE,
 } from '../../../shared/abis/index.js'
 import { Logger } from '../../../shared/logger/index.js'
-import { MempoolManager } from '../mempool/index.js'
 import { ProviderService } from '../../../shared/provider/index.js'
 import {
   SendBundleReturnWithSigner,
@@ -35,7 +34,6 @@ export type BundleProcessor = {
 export const createBundleProcessor = (
   providerService: ProviderService,
   reputationManager: ReputationManager,
-  mempoolManager: MempoolManager,
   entryPointContract: ethers.Contract,
   txMode: string,
   beneficiary: string,
@@ -150,6 +148,7 @@ export const createBundleProcessor = (
         return {
           transactionHash: ret,
           userOpHashes: hashes,
+          signerIndex,
         } as SendBundleReturnWithSigner
       } catch (e: any) {
         let parsedError: ErrorDescription
@@ -180,8 +179,6 @@ export const createBundleProcessor = (
           reputationManager.crashedHandleOps(userOp.factory)
         }
 
-        // remove failed UserOp from mempool
-        await mempoolManager.removeUserOp(userOp)
         Logger.warn(
           `Failed handleOps sender=${userOp.sender} reason=${reasonStr}`,
         )
@@ -190,6 +187,7 @@ export const createBundleProcessor = (
           transactionHash: '',
           userOpHashes: [],
           signerIndex,
+          failedOp: userOp,
         }
       }
     },

--- a/packages/bundler-builder/src/event/event-manager-with-reputation.ts
+++ b/packages/bundler-builder/src/event/event-manager-with-reputation.ts
@@ -3,7 +3,7 @@ import { ethers } from 'ethers'
 import { Logger } from '../../../shared/logger/index.js'
 import { ProviderService } from '../../../shared/provider/index.js'
 import { ReputationManager } from '../reputation/index.js'
-import { MempoolManager } from '../mempool/index.js'
+import { MempoolManageUpdater } from '../mempool/index.js'
 
 export type EventManagerWithListener = {
   /**
@@ -15,7 +15,7 @@ export type EventManagerWithListener = {
 export const createEventManagerWithListener = (
   providerService: ProviderService,
   reputationManager: ReputationManager,
-  mempoolManager: MempoolManager,
+  mempoolManageUpdater: MempoolManageUpdater,
   entryPointContract: ethers.Contract,
 ): EventManagerWithListener => {
   let lastBlock: number | null = null
@@ -83,13 +83,13 @@ export const createEventManagerWithListener = (
         { userOpHash },
         'UserOperationEvent success. Removing from mempool',
       )
-      await mempoolManager.removeUserOp(userOpHash)
+      await mempoolManageUpdater.removeUserOp(userOpHash)
     } else {
       Logger.debug(
         { userOpHash },
         'UserOperationEvent failed. Updating status in mempool',
       )
-      await mempoolManager.updateEntryStatus(userOpHash, 'failed')
+      await mempoolManageUpdater.updateEntryStatus(userOpHash, 'failed')
     }
 
     // TODO: Make this a batch operation

--- a/packages/bundler-builder/src/handler/apis/Debug.ts
+++ b/packages/bundler-builder/src/handler/apis/Debug.ts
@@ -7,7 +7,7 @@ import { StakeInfo } from '../../../../shared/validatation/index.js'
 import { ethers, BigNumber } from 'ethers'
 import { ReputationEntry, ReputationManager } from '../../reputation/index.js'
 import { BundleManager } from '../../bundle/index.js'
-import { MempoolManager } from '../../mempool/index.js'
+import { MempoolManagerCore } from '../../mempool/index.js'
 import { EventManagerWithListener } from '../../event/index.js'
 
 export type DebugAPI = {
@@ -28,22 +28,22 @@ export type DebugAPI = {
 export const createDebugAPI = (
   bundleManager: BundleManager,
   reputationManager: ReputationManager,
-  mempoolManager: MempoolManager,
+  mempoolManagerCore: MempoolManagerCore,
   eventsManager: EventManagerWithListener,
   entryPointContract: ethers.Contract,
 ): DebugAPI => {
   return {
     clearState: async (): Promise<void> => {
-      await mempoolManager.clearState()
+      await mempoolManagerCore.clearState()
       await reputationManager.clearState()
     },
 
     dumpMempool: async () => {
-      return await mempoolManager.dump()
+      return await mempoolManagerCore.dump()
     },
 
     clearMempool: async (): Promise<void> => {
-      await mempoolManager.clearState()
+      await mempoolManagerCore.clearState()
     },
 
     setBundlingMode: (mode: string): boolean => {
@@ -73,7 +73,7 @@ export const createDebugAPI = (
         const userOpHash = await entryPointContract.getUserOpHash(
           packUserOp(userOp),
         )
-        await mempoolManager.addUserOp({
+        await mempoolManagerCore.addUserOp({
           userOp,
           userOpHash,
           prefund: BigNumber.from(0),

--- a/packages/bundler-builder/src/handler/handlerRegistry.ts
+++ b/packages/bundler-builder/src/handler/handlerRegistry.ts
@@ -1,14 +1,14 @@
-import { MempoolManager } from '../mempool/index.js'
 import type { HandlerRegistry } from '../../../shared/rpc/index.js'
 
 import { DebugAPI } from './apis/index.js'
+import { MempoolManageSender } from '../mempool/index.js'
 
 export const createRelayerHandlerRegistry = (
   debug: DebugAPI,
-  mempool: MempoolManager,
+  mempoolManageSender: MempoolManageSender,
 ): HandlerRegistry => ({
   builder_addUserOp: async (params) => {
-    await mempool.addUserOp(params[0])
+    await mempoolManageSender.addUserOp(params[0])
     return 'ok'
   },
 

--- a/packages/bundler-builder/src/mempool/mempool-manager.test.ts
+++ b/packages/bundler-builder/src/mempool/mempool-manager.test.ts
@@ -5,17 +5,20 @@ import {
   mockEntryPointGetUserOpHash,
 } from '../../test/test-helpers.js'
 import { createMempoolState } from './mempool-state.js'
-import { createMempoolManager, MempoolManager } from './mempool-manager.js'
+import {
+  createMempoolManagerCore,
+  MempoolManagerCore,
+} from './mempool-manager.js'
 import { mockReputationManager } from '../../test/mocks/index.js'
 import { BigNumber } from 'ethers'
 
-describe('MempoolManager', () => {
-  let mempoolManager: MempoolManager
+describe('MempoolManagerCore', () => {
+  let mempoolManager: MempoolManagerCore
   const MOCK_BUNDLE_SIZE = 5
 
   beforeEach(() => {
     vi.clearAllMocks()
-    mempoolManager = createMempoolManager(
+    mempoolManager = createMempoolManagerCore(
       createMempoolState(),
       mockReputationManager,
       MOCK_BUNDLE_SIZE,

--- a/packages/shared/types/bundle.types.ts
+++ b/packages/shared/types/bundle.types.ts
@@ -1,3 +1,5 @@
+import { UserOperation } from '../../shared/types/index.js'
+
 export type SlotMap = {
   [slot: string]: string
 }
@@ -19,4 +21,5 @@ export type SendBundleReturnWithSigner = {
   transactionHash: string
   userOpHashes: string[]
   signerIndex: number
+  failedOp?: UserOperation
 }


### PR DESCRIPTION
Define a subset of types that only exposes the necessary methods for more granular `MempoolManager` interfaces. A granular interface will prevent other parts of bundler code from misusing the `MempoolManager`. 