### PR TITLE
feat: enforce EREP-015

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -8,5 +8,5 @@ Set of helper contracts for the Transeptor bundler.
 ## Compile
 
 ```bash
-npm run build:contracts
+yarn build:contracts
 ```

--- a/packages/bundler-builder/src/index.ts
+++ b/packages/bundler-builder/src/index.ts
@@ -14,7 +14,10 @@ import { createProviderService } from '../../shared/provider/index.js'
 import { createValidationService } from '../../shared/validatation/index.js'
 import { createSimulator } from '../../shared/sim/index.js'
 import { createSignerService } from './signer/index.js'
-import { createReputationManager } from './reputation/index.js'
+import {
+  createReputationManager,
+  createReputationManagerUpdater,
+} from './reputation/index.js'
 import {
   createMempoolManagerBuilder,
   createMempoolManagerCore,
@@ -89,6 +92,7 @@ const runBundlerBuilder = async () => {
     ),
     eventManager,
     createMempoolManagerBuilder(mempoolManagerCore),
+    createReputationManagerUpdater(reputationManager),
     config.isAutoBundle,
     config.autoBundleInterval,
   )

--- a/packages/bundler-builder/src/mempool/mempool-manager.ts
+++ b/packages/bundler-builder/src/mempool/mempool-manager.ts
@@ -266,7 +266,7 @@ export const createMempoolManagerCore = (
     userOp: UserOperation,
   ): Promise<void> => {
     try {
-      await reputationManager.updateSeenStatus(userOp.sender)
+      await reputationManager.updateSeenStatus(userOp.sender, 'increment')
     } catch (e: any) {
       if (!(e instanceof RpcError)) throw e
     }

--- a/packages/bundler-builder/src/reputation/reputation.types.ts
+++ b/packages/bundler-builder/src/reputation/reputation.types.ts
@@ -42,8 +42,12 @@ export type ReputationManager = {
    * Update the last seen status of an entity.
    *
    * @param addr - The address of the entity that is seen.
+   * @param action - The action to perform (increment or decrement).
    */
-  updateSeenStatus(addr?: string): Promise<void>
+  updateSeenStatus(
+    addr: string | undefined,
+    action: 'increment' | 'decrement',
+  ): Promise<void>
 
   /**
    * Update the last seen status of an entity.
@@ -124,3 +128,8 @@ export type ReputationManager = {
    */
   calculateMaxAllowedMempoolOpsUnstaked(entity: string): Promise<number>
 }
+
+export type ReputationManagerUpdater = Pick<
+  ReputationManager,
+  'updateSeenStatus'
+>

--- a/packages/bundler-relayer/src/handler/apis/Eth.ts
+++ b/packages/bundler-relayer/src/handler/apis/Eth.ts
@@ -50,7 +50,11 @@ const validateParameters = async (
     )
   }
   // minimal sanity check: userOp exists, and all members are hex
-  requireCond(userOp1 != null, 'No UserOperation param')
+  requireCond(
+    userOp1 != null,
+    'No UserOperation param',
+    ValidationErrors.InvalidFields,
+  )
   const userOp = (await resolveProperties(userOp1)) as any
 
   const fields = ['sender', 'nonce', 'callData']

--- a/packages/shared/utils/rpc.utils.ts
+++ b/packages/shared/utils/rpc.utils.ts
@@ -3,7 +3,7 @@ import { hexlify } from 'ethers/lib/utils.js'
 export const requireCond = (
   cond: boolean,
   msg: string,
-  code?: number,
+  code: number,
   data: any = undefined,
 ): void => {
   if (!cond) {
@@ -15,7 +15,7 @@ export class RpcError extends Error {
   // error codes from: https://eips.ethereum.org/EIPS/eip-1474
   constructor(
     msg: string,
-    readonly code?: number,
+    readonly code: number,
     readonly data: any = undefined,
   ) {
     super(msg)

--- a/packages/shared/utils/validation.utils.ts
+++ b/packages/shared/utils/validation.utils.ts
@@ -23,12 +23,12 @@ type ValidationData = {
  * @param mustFields - The fields that must be present.
  * @param optionalFields - The fields that are optional.
  */
-export function requireAddressAndFields(
+export const requireAddressAndFields = (
   userOp: UserOperation,
   addrField: string,
   mustFields: string[],
   optionalFields: string[] = [],
-): void {
+): void => {
   const op = userOp as any
   const addr = op[addrField]
   if (addr == null) {
@@ -64,10 +64,10 @@ export function requireAddressAndFields(
  * @param paymasterValidationData - Paymaster validation data.
  * @returns Aggregator, validAfter, validUntil.
  */
-export function mergeValidationData(
+export const mergeValidationData = (
   accountValidationData: ValidationData,
   paymasterValidationData: ValidationData,
-): ValidationData {
+): ValidationData => {
   return {
     aggregator:
       paymasterValidationData.aggregator !== ethers.constants.AddressZero
@@ -90,9 +90,9 @@ export function mergeValidationData(
  * @param validationData - Validation data.
  * @returns Aggregator, validAfter, validUntil.
  */
-export function parseValidationData(
+export const parseValidationData = (
   validationData: BigNumberish,
-): ValidationData {
+): ValidationData => {
   const data = hexZeroPad(BigNumber.from(validationData).toHexString(), 32)
 
   // string offsets start from left (msb)
@@ -115,12 +115,29 @@ export function parseValidationData(
  * @param paymasterValidationData - Paymaster validation data.
  * @returns Aggregator, validAfter, validUntil.
  */
-export function mergeValidationDataValues(
+export const mergeValidationDataValues = (
   accountValidationData: BigNumberish,
   paymasterValidationData: BigNumberish,
-): ValidationData {
+): ValidationData => {
   return mergeValidationData(
     parseValidationData(accountValidationData),
     parseValidationData(paymasterValidationData),
+  )
+}
+
+/**
+ * Check if the error is related to account or factory.
+ *
+ * @param code - The error code.
+ * @param errorMessage - The error message.
+ * @returns Whether the error is related to account or factory.
+ */
+export const isAccountOrFactoryError = (
+  code: ValidationErrors,
+  errorMessage: string,
+): boolean => {
+  return (
+    code === ValidationErrors.SimulateValidation &&
+    errorMessage.match(/FailedOpWithRevert\(\d+,"AA[21]/) != null
   )
 }


### PR DESCRIPTION
**[EREP-015]** A `paymaster` should not have its opsSeen incremented on failure of factory or account. When running 2nd validation (before inclusion in a bundle), if a UserOperation fails because of factory or account error (either a FailOp revert or validation rule), then the paymaster's opsSeen valid is decremented by 1. 

```bash
========================================================================= short test summary info ==========================================================================
PASSED tests/single/reputation/test_erep.py::test_paymaster_on_account_failure
=============================================================== 1 passed, 183 deselected, 1 warning in 1.95s ===============================================================
```