### PR TITLE
Update hardfork config when preparing a 7702 tx

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Our long-term vision is to:
 
 - **Run it yourself** - Make it easy for anyone to run their own bundler node.
 - **Promote bundler diversity and reduce centralization risks** — We are committed to decentralization by offering public bundlers anyone can use, and empowering developers to run and customize their own.
-- **Bundler compatibility** - Maintain strict compatibility with [erc-4337/bundler-spec-test](https://www.erc4337.io/bundlers) to preserve the vision of a [Unified ERC-4337 mempool](https://notes.ethereum.org/@yoav/unified-erc-4337-mempool).
+- **Bundler compatibility** - Maintain strict compatibility with [erc-4337/bundler-spec-test](https://bundlers.erc4337.io/) to preserve the vision of a [Unified ERC-4337 mempool](https://notes.ethereum.org/@yoav/unified-erc-4337-mempool).
 - **Embrace the Future** - Experiment safely with advanced features to push bundler UX and performance forward. Any system that can be written down can be realized.
 
 By contributing to Transeptor bundler, you're helping build an open, composable infrastructure layer that strengthens Ethereum’s decentralization and usability without requiring any changes to the protocol.

--- a/eth-node
+++ b/eth-node
@@ -32,10 +32,9 @@ start_geth_with_erc7562_native_tracer() {
     --dev \
     --dev.period 0 \
     --maxpeers 0 \
-    --nodiscover \
     --allow-insecure-unlock \
     --rpc.allow-unprotected-txs \
-    --dev.gaslimit  12000000 )
+    --dev.gaslimit  20000000 )
 
   sleep 4
 

--- a/src/utils/eip-7702.utils.ts
+++ b/src/utils/eip-7702.utils.ts
@@ -93,7 +93,7 @@ export const prepareEip7702Transaction = async (
     chainId: 1337,
   }
 
-  const common = new Common({ chain, hardfork: Hardfork.Cancun, eips: [7702] })
+  const common = new Common({ chain, eips: [2718, 2929, 2930, 7702] })
   const authorizationList = eip7702Tuples.map((it) => {
     return {
       chainId: toRlpHex(it.chainId) as PrefixedHexString,
@@ -121,11 +121,11 @@ export const prepareEip7702Transaction = async (
       tx.maxPriorityFeePerGas!,
     ) as PrefixedHexString,
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    maxFeePerGas: toBeHex(tx.maxPriorityFeePerGas!) as PrefixedHexString,
+    maxFeePerGas: toBeHex(tx.maxFeePerGas!) as PrefixedHexString,
+    gasLimit: toBeHex(10_000_000) as PrefixedHexString,
     accessList: [],
     authorizationList,
   }
-  txData.gasLimit = 10_000_000
 
   const objectTx = createEOACode7702Tx(txData, { common })
   const privateKeyBytes: Uint8Array = getBytes(signer.privateKey)


### PR DESCRIPTION
Make sure we are using the `prague` hardfork configuration with `@ethereumjs/tx` lib as it includes EIP-7702 Transactions: https://www.npmjs.com/package/@ethereumjs/tx#chain-and-hardfork-support